### PR TITLE
Introducing environment variables in webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,85 @@ module.exports = {
 
 8. Webpack bundle walkthrough using command `npm run webpack`. Go through the build file(`main.js`) to undestand how webpack runtime works.
 
+9. Webpack input, output & loaders configurations
+
+Loaders
+```js
+module: {
+	rules: [
+		{test: /\.ts$/, use: 'ts-loader'},
+		{test: /\.js$/, use: 'babel-loader'},
+		{test: /\.css$/, use: 'css-loader'}
+	]
+}
+```
+
+```js
+module: {
+	rules: [
+		{
+			test: regex,
+			use: (Array|String|Function),
+			include: RegExp[],
+			exclude: RegExp[],
+			issuer: (RegExp|String)[],
+			enforce: 'pre'|'post'
+		}
+	]
+}
+```
+
+10. Chaining loaders - Tells webpack how to interpret and translate files. Transformed on a per-file basis before adding to the dependency graph.
+
+11. Webpack plugins 
+ a. objects (with and `apply` property)
+ b. Allow to hook into the entire compilation lifecyle
+ c. lots / varities of available plugins
+
+12. Basic plugin example - Plugin is an ES5 'class' which implements an apply function. The compiler uses it to emit events
+
+```js
+function SamplePlugin(){}
+
+SamplePlugin.prototype.apple = function(compiler){
+	if(typeof(process) !== 'undefined'){
+		compiler.plugin('done', function(stats){
+			if(stats.hasErrors()){
+				process.stderr.write('\x07')
+			}
+		});
+
+		compiler.plugin('failed', function(err){
+			process.stderr.write('\x07')
+		})
+	}
+}
+
+module.exports = SamplePlugin
+
+
+//Usage
+//require() from node_modules or webpack or local file
+modules.exports = {
+	//...
+	plugins:[
+		new SamplePlugin()
+	]
+	//..
+}
+```
+
+13. Webpack config - `npm run prod`
+
+```js
+module.exports = ({mode}) => {
+	console.log(mode)
+	return {
+		mode,
+		output: {
+			filename: 'bundle.js'
+		}	
+	}
+}
+```
+

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "scripts": {
   	"webpack": "webpack",
   	"debug":"node --inspect --inspect-brk ./node_modules/webpack/bin/webpack.js",
-  	"dev":"npm run webpack -- --mode development",
+  	"dev":"npm run webpack -- --env.mode development",
   	"dev:watch": "npm run dev -- --watch",
-  	"prod": "npm run webpack -- --mode production",
-  	"prod:debug":"npm run debug -- --mode production",
-  	"dev:debug":"npm run debug -- --mode development",
+  	"prod": "npm run webpack -- --env.mode production",
+  	"prod:debug":"npm run debug -- --env.mode production",
+  	"dev:debug":"npm run debug -- --env.mode development",
   	"debugthis": "node --inspect --inspect-brk ./src/index.js"
   },
   "dependencies": {},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,9 @@
-module.exports = {
-	mode: 'none'
+module.exports = ({mode}) => {
+	console.log(mode)
+	return {
+		mode,
+		output: {
+			filename: 'bundle.js'
+		}	
+	}
 }


### PR DESCRIPTION
## Introducing webpack environment variables in webpack
Using pipe operator in npm scripts. You can pass environment variables from triggers to webpack configurations.

```json
"prod": "npm run webpack -- --env.mode production",
"dev":"npm run webpack -- --env.mode development",
```
Using environment variables in `webpack.config.js`

```js
module.exports = ({mode}) => {
	console.log(mode)
	return {
		mode,
		output: {
			filename: 'bundle.js'
		}	
	}
}
```