### PR TITLE
Adding html-webpack-plugin in build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,7 @@ module.exports = ({mode}) => {
 }
 ```
 
+14. Adding webpack plugins - Starting with `html-webpack-plugin` & `progressPlugin`
+
+15.
+

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.16.3"
   },
   "repository": "git@github.com:samarpanda/webpack-setup.git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,16 @@
+const webpack = require('webpack')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+
 module.exports = ({mode}) => {
 	console.log(mode)
 	return {
 		mode,
 		output: {
 			filename: 'bundle.js'
-		}	
+		},
+		plugins: [
+			new HtmlWebpackPlugin(),
+			new webpack.ProgressPlugin()
+		]
 	}
 }


### PR DESCRIPTION
## Adding html-wepack-plugin in the build process
Adding html-webpack-plugin & webpack.ProgressPlugin in build process. `html-webpack-plugin` creates a `index.html` in the distribution directory with js / css files already attached to it.