### PR TITLE
Split environment mode config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,6 @@ module.exports = ({mode}) => {
 
 15. Adding `webpack-dev-server` for development environment. Try command `npm run dev`. You can see a button added to the browser & changes are reflecting instantly.
 
+16. Splitting environment config files, using webpack-merge & modeConfigs
+
+17. Setting default preset configurations

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.16.3",
-    "webpack-dev-server": "^3.1.5"
+    "webpack-dev-server": "^3.1.5",
+    "webpack-merge": "^4.1.3"
   },
   "repository": "git@github.com:samarpanda/webpack-setup.git",
   "author": "Samar Panda <er.samarpanda@gmail.com>",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,12 @@
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+const webpackMerge = require('webpack-merge')
 
-module.exports = ({mode}) => {
-	console.log(mode)
-	return {
+const modeConfig = env => require(`./build-utils/webpack.${env}`)(env)
+
+module.exports = ({ mode, presets } = { mode: 'production', presets: [] }) => {
+	console.log(mode, presets)
+	return webpackMerge({
 		mode,
 		output: {
 			filename: 'bundle.js'
@@ -12,5 +15,7 @@ module.exports = ({mode}) => {
 			new HtmlWebpackPlugin(),
 			new webpack.ProgressPlugin()
 		]
-	}
+	},
+		modeConfig(mode)
+	)
 }


### PR DESCRIPTION
## How to split webpack configuration as per production and development
Include build based configuration file by below line of code

Details of `webpack.config.js`
```js
const webpack = require('webpack')
const webpackMerge = require('webpack-merge')

const modeConfig = env => require(`./build-utils/webpack.${env}`)(env)

module.exports = ({ mode, presets } = { mode: 'production', presets: [] }) => {
  console.log(mode, presets)
 return webpackMerge({
   mode,
   output: {
     filename: 'bundle.js'
   },
 },
    modeConfig(mode)
  )
}
```

package.json
```json
{
  "scripts": {
  "webpack": "webpack",
  "dev": "npm run webpack -- --env.mode development",
  "prod": "npm run webpack -- --env.mode production"
  },
  "devDependencies": {
    "webpack": "webpack",
  }
}
```

Development build - `npm run dev`
Production build - `npm run prod`
